### PR TITLE
Adds functionality to limit redirection to specific hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.3 (February 27, 2014)
+
+- Added option to specify on which hosts to perform redirection
+
+
 ## 0.0.2 (June 14, 2011)
 
 - Populate CHANGELOG.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ middleware at the top of the Rack stack::
       end
     end
 
+You can also specify the `:only_hosts` parameter to limit redirection to specific hosts
+
+    config.middleware.use(Rack::NoWWW, only_hosts: "www.example.org")
+
+Requests not made on www.example.org will not be redirected to the root domain.
+
 
 Credits
 -------

--- a/lib/rack/no-www.rb
+++ b/lib/rack/no-www.rb
@@ -15,7 +15,7 @@ module Rack
     end
 
     def call(env)
-      if require_direct?
+      if require_redirect?
         [301, no_www_request(env), ["Moved Permanently\n"]]
       else
         @app.call(env)

--- a/lib/rack/no-www.rb
+++ b/lib/rack/no-www.rb
@@ -15,6 +15,7 @@ module Rack
     end
 
     def call(env)
+      @env = env
       if require_redirect?
         [301, no_www_request(env), ["Moved Permanently\n"]]
       else
@@ -25,11 +26,11 @@ module Rack
   private
 
     def require_redirect?
-      env['HTTP_HOST'] =~ STARTS_WITH_WWW && host_match?
+      @env['HTTP_HOST'] =~ STARTS_WITH_WWW && host_match?
     end
 
     def host_match?
-      @options[:only_hosts].include?(env['HTTP_HOST']) unless @options[:only_hosts].empty?
+      @options[:only_hosts].include?(@env['HTTP_HOST']) unless @options[:only_hosts].empty?
     end
   
     def no_www_request(env)

--- a/lib/rack/no-www.rb
+++ b/lib/rack/no-www.rb
@@ -5,19 +5,33 @@ module Rack
 
     STARTS_WITH_WWW = /^www\./i
 
-    def initialize(app)
+    def initialize(app, options={})
+      default_options = {
+        only_hosts: []
+      }
+
       @app = app
+      @options = default_options.merge(options)
     end
 
     def call(env)
-      if env['HTTP_HOST'] =~ STARTS_WITH_WWW
+      if require_direct?
         [301, no_www_request(env), ["Moved Permanently\n"]]
       else
         @app.call(env)
       end
     end
 
-    private
+  private
+
+    def require_redirect?
+      env['HTTP_HOST'] =~ STARTS_WITH_WWW && host_match?
+    end
+
+    def host_match?
+      @options[:only_hosts].include?(env['HTTP_HOST']) unless @options[:only_hosts].empty?
+    end
+  
     def no_www_request(env)
       { 'Location' => Rack::Request.new(env).url.sub(/www\./i, ''),
         'Content-Type' => 'text/html' }

--- a/lib/rack/no-www.rb
+++ b/lib/rack/no-www.rb
@@ -17,9 +17,9 @@ module Rack
     def call(env)
       @env = env
       if require_redirect?
-        [301, no_www_request(env), ["Moved Permanently\n"]]
+        [301, no_www_request, ["Moved Permanently\n"]]
       else
-        @app.call(env)
+        @app.call(@env)
       end
     end
 
@@ -30,11 +30,11 @@ module Rack
     end
 
     def host_match?
-      @options[:only_hosts].include?(@env['HTTP_HOST']) unless @options[:only_hosts].empty?
+      @options[:only_hosts].include?(@env['HTTP_HOST']) || @options[:only_hosts].empty?
     end
   
-    def no_www_request(env)
-      { 'Location' => Rack::Request.new(env).url.sub(/www\./i, ''),
+    def no_www_request
+      { 'Location' => Rack::Request.new(@env).url.sub(/www\./i, ''),
         'Content-Type' => 'text/html' }
     end
 

--- a/lib/rack/no-www/version.rb
+++ b/lib/rack/no-www/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class NoWWW
-    VERSION = "0.0.2"
+    VERSION = "0.0.4"
   end
 end

--- a/lib/rack/no-www/version.rb
+++ b/lib/rack/no-www/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class NoWWW
-    VERSION = "0.0.4"
+    VERSION = "0.0.3"
   end
 end

--- a/spec/rack_no_www_spec.rb
+++ b/spec/rack_no_www_spec.rb
@@ -9,28 +9,53 @@ describe "Rack::NoWWW" do
     app = Rack::NoWWW.new(mock_endpoint)
   end
 
+
+
   describe "when receiving a request with a 'www'" do
+    context "without the only_hosts parameter" do
+      let(:app) { ->(env) { [200, env, "app"] } }
+  
+      let :middleware do
+        Rack::NoWWW.new(app)
+      end
 
-    before(:each) do
-      request '/', {'HTTP_HOST' => 'www.example.org' }
+      before(:each) do
+        request '/', {'HTTP_HOST' => 'www.example.org' }
+      end
+
+      it "should issue a 301 redirect" do
+        last_response.status.should == 301
+      end
+
+      it "should redirect to the URL without the 'www'" do
+        last_response.headers['Location'].should == "http://example.org/"
+      end
+
+      it "should have a text/html content type" do
+        last_response.headers['Content-Type'].should == "text/html"
+      end
+
+      it "should have a body of 'Moved Permanently\\n'" do
+        last_response.body.should == "Moved Permanently\n"
+      end
+      
     end
 
-    it "should issue a 301 redirect" do
-      last_response.status.should == 301
-    end
+    context "with the only_hosts parameter not matching the domain" do
+      let(:app) { ->(env) { [200, env, "app"] } }
+  
+      let :middleware do
+        Rack::NoWWW.new(app, only_hosts: ['www.example.org'])
+      end
 
-    it "should redirect to the URL without the 'www'" do
-      last_response.headers['Location'].should == "http://example.org/"
-    end
+      before(:each) do
+        request '/', {'HTTP_HOST' => 'www.non-redirecting-host.org' }
+      end
 
-    it "should have a text/html content type" do
-      last_response.headers['Content-Type'].should == "text/html"
+      it "should not issue a 301 redirect when proper only_hosts param specified" do
+        last_response.status.should == 200
+      end
     end
-
-    it "should have a body of 'Moved Permanently\\n'" do
-      last_response.body.should == "Moved Permanently\n"
-    end
-    
   end
 
   describe "when receiving a request without a 'www'" do


### PR DESCRIPTION
I followed suit of rack-ssl-enforcer by adding an `:only_hosts` option. 
